### PR TITLE
Make prettier run on precommit hooks automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,16 @@
   "version": "0.0.5",
   "description": "Immutable date wrapper",
   "author": "Isaac Cambron",
-  "keywords": [
-    "date",
-    "immutable"
-  ],
+  "keywords": ["date", "immutable"],
   "repository": "https://github.com/icambron/luxon",
   "dependencies": {
     "core-js": "latest"
+  },
+  "scripts": {
+    "precommit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.{js,json,css}": ["prettier --config .prettier.js --write", "git add"]
   },
   "devDependencies": {
     "babel-jest": "latest",
@@ -32,12 +35,14 @@
     "gulp-rename": "latest",
     "gulp-sourcemaps": "latest",
     "gulp-uglify": "latest",
+    "husky": "^0.14.3",
     "jest-cli": "latest",
     "lazypipe": "latest",
+    "lint-staged": "^4.3.0",
     "prettier": "latest",
     "rollup-plugin-babel": "latest",
-    "rollup-plugin-node-resolve": "latest",
     "rollup-plugin-commonjs": "latest",
+    "rollup-plugin-node-resolve": "latest",
     "rollup-stream": "latest",
     "run-sequence": "latest",
     "tap-min": "latest",


### PR DESCRIPTION
Normal commit hooks often require modifying files within the .git
directory manually. However, `husky` and `pre-commit` together make it
so you don't have to do anything special to run prettier against files
automatically as they are being committed. This ensures that any file
changed is automatically updated when committed.

- Add husky and precommit to the package, along with a precommit script
that will run prettier for any staged file

Note that this is the process that prettier [recommends here](https://github.com/prettier/prettier#pre-commit-hook). This addresses https://github.com/icambron/luxon/issues/27